### PR TITLE
Initial containerization of machiavelli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:jessie
+MAINTAINER engineering@anchor.net.au
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	ca-certificates \
+	git \
+	build-essential \
+	wget \
+	ruby \
+	ruby-dev \
+	redis-server \
+	openssl \
+	unicorn
+
+# Setup Redis as proper service
+ADD redis_init.sh /etc/init.d/redis-server
+RUN update-rc.d redis-server defaults
+
+RUN gem install bundler
+
+RUN git clone https://github.com/anchor/machiavelli
+RUN cd machiavelli && bundle install --without development
+
+ADD start-machiavelli.sh /start-machiavelli.sh
+
+# Uniconr-based setup
+ADD unicorn.rb /machiavelli/config/unicorn.rb
+RUN mkdir -p /machiavelli/tmp/pids
+RUN mkdir -p /machiavelli/tmp/cache
+RUN mkdir -p /machiavelli/tmp/sockets
+RUN mkdir -p /machiavelli/log
+
+WORKDIR /machiavelli
+
+EXPOSE 80
+
+ENTRYPOINT "/start-machiavelli.sh"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ WORKDIR /machiavelli
 
 EXPOSE 80
 
-ENTRYPOINT "/start-machiavelli.sh"
+ENTRYPOINT ["/start-machiavelli.sh"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # docker-machiavelli
 Docker build scripts for machiavelli
 
+# Sample configuration
+
+Run the dockerised machiavelli using the host filesystem's config yaml file as the settings: 
+
+    docker run -v machiavelli-config.yml:/machiavelli/config/settings.yml anchor/machiavelli

--- a/machiavelli-config.yml
+++ b/machiavelli-config.yml
@@ -1,0 +1,10 @@
+origins:
+        "Simple": {
+                store: "Simple",
+                source: "Source",
+                title: "Simple",
+                store_settings: {
+                        url: "http://localhost:4567",
+                }
+        }
+

--- a/redis_init.sh
+++ b/redis_init.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Simple Redis init.d script conceived to work on Linux systems
+# as it does use of the /proc filesystem.
+
+REDISPORT=6379
+EXEC=/usr/bin/redis-server
+CLIEXEC=/usr/bin/redis-cli
+
+PIDFILE=/var/run/redis.pid
+CONF="/etc/redis/redis.conf"
+
+case "$1" in
+    start)
+        if [ -f $PIDFILE ]
+        then
+                echo "$PIDFILE exists, process is already running or crashed"
+        else
+                echo "Starting Redis server..."
+                $EXEC $CONF
+        fi
+        ;;
+    stop)
+        if [ ! -f $PIDFILE ]
+        then
+                echo "$PIDFILE does not exist, process is not running"
+        else
+                PID=$(cat $PIDFILE)
+                echo "Stopping ..."
+                $CLIEXEC -p $REDISPORT shutdown
+                while [ -x /proc/${PID} ]
+                do
+                    echo "Waiting for Redis to shutdown ..."
+                    sleep 1
+                done
+                echo "Redis stopped"
+        fi
+        ;;
+    *)
+        echo "Please use start or stop as first argument"
+        ;;
+esac

--- a/start-machiavelli.sh
+++ b/start-machiavelli.sh
@@ -2,5 +2,4 @@
 set -e
 
 /etc/init.d/redis-server start
-bundle exec rails server -p 80
-#RAILS_ENV=production /usr/bin/unicorn -D -c config/unicorn.rb
+RAILS_ENV=production /usr/bin/unicorn -D -c config/unicorn.rb

--- a/start-machiavelli.sh
+++ b/start-machiavelli.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 /etc/init.d/redis-server start
 bundle exec rails server -p 80
 #RAILS_ENV=production /usr/bin/unicorn -D -c config/unicorn.rb

--- a/start-machiavelli.sh
+++ b/start-machiavelli.sh
@@ -1,0 +1,3 @@
+/etc/init.d/redis-server start
+bundle exec rails server -p 80
+#RAILS_ENV=production /usr/bin/unicorn -D -c config/unicorn.rb

--- a/unicorn.rb
+++ b/unicorn.rb
@@ -1,0 +1,18 @@
+working_directory "/machiavelli"
+
+# Unicorn PID file location
+pid "/machiavelli/tmp/pids/unicorn.pid"
+
+# Path to logs
+stderr_path "/machiavelli/log/unicorn.log"
+stdout_path "/machiavelli/log/unicorn.log"
+
+# Unicorn socket
+listen "/machiavelli/tmp/sockets/unicorn.machiavelli.sock"
+
+# Number of processes
+worker_processes 2
+
+# Time-out
+timeout 30
+


### PR DESCRIPTION
- Uses jessie because it has ruby 2.1 (wheezy has 1.9.3, which is EOL shortly). 
- Uses unicorns, because unicorns are awesome
- Uses redis internal service, see anchor/machiavelli#96 for possible removal of redis entirely. Keeping as an on-board service for now. 
- Uses `docker -v` for run-time Machiavelli config file, see readme invocation. 
